### PR TITLE
Add GitHub Skills activity to course offerings

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to enhance college applications",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## 🚨 Fixes Issue #6: Missing Activity - GitHub Skills

### Summary
Adds the GitHub Skills extracurricular activity that was announced by the principal but was missing from the signup system.

### Changes Made
- ✅ Added "GitHub Skills" activity to the activities database
- ✅ Configured with appropriate schedule (Wednesdays, 3:30 PM - 5:00 PM)
- ✅ Set maximum capacity to 25 students
- ✅ Included description referencing the GitHub Certifications program

### Activity Details
- **Description**: Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to enhance college applications
- **Schedule**: Wednesdays, 3:30 PM - 5:00 PM
- **Max Participants**: 25
- **Current Enrollment**: 0 (ready for student registrations)

### Impact
This resolves the time-sensitive issue where students were unable to sign up for the GitHub Skills activity before the deadline at the end of this week.

Closes #6